### PR TITLE
feat: support partial string match in `find` command

### DIFF
--- a/src/main/java/seedu/rex/ui/Rex.java
+++ b/src/main/java/seedu/rex/ui/Rex.java
@@ -224,7 +224,7 @@ public class Rex {
 
     /**
      * Handles the {@code find} command by searching for tasks containing a keyword.
-     *
+     * Includes handling of partial text matchz
      * @param args the argument string containing the search keyword
      * @return a list of matching tasks, or an error/no-match message
      */

--- a/src/main/java/seedu/rex/ui/Rex.java
+++ b/src/main/java/seedu/rex/ui/Rex.java
@@ -7,6 +7,7 @@ import seedu.rex.tasks.Deadline;
 import seedu.rex.tasks.Event;
 
 import seedu.rex.utils.DateTimeUtil;
+import seedu.rex.utils.Parser;
 import seedu.rex.utils.Storage;
 
 import java.nio.file.Path;
@@ -39,6 +40,21 @@ public class Rex {
     private TaskList taskList;
     private boolean isRunning;
 
+    // Messages to avoid magic strings
+    private static final String UNKNOWN_COMMAND_MSG =
+            "Unknown command. Try 'list', 'todo', 'deadline', 'event', 'mark', 'unmark', 'delete', 'find', or 'bye'.";
+
+    private static final String ERR_DELETE_IDX = "Invalid task number for delete.";
+    private static final String ERR_MARK_IDX   = "Invalid task number for mark.";
+    private static final String ERR_UNMARK_IDX = "Invalid task number for unmark.";
+    private static final String ERR_TODO_EMPTY = "Todo description cannot be empty!";
+    private static final String ERR_FIND_USAGE = "Usage: find <keyword>";
+
+    private static final String USAGE_DEADLINE =
+            "Usage: deadline <description> /by <yyyy-MM-dd[ HHmm]>";
+    private static final String USAGE_EVENT =
+            "Usage: event <desc> /from <yyyy-MM-dd[ HHmm]> /to <yyyy-MM-dd[ HHmm]>";
+
     /**
      * Constructor for Rex chatbot.
      * Initializes the task list by loading from storage or creating a new one.
@@ -70,6 +86,206 @@ public class Rex {
     }
 
     /**
+     * Exits the chatbot, saves the current task list, and returns a farewell message.
+     *
+     * @return the farewell message string
+     */
+    private String handleBye() {
+        isRunning = false;
+        try {
+            Storage.save(DATA_PATH, new ArrayList<>(taskList.asList()));
+        } catch (Exception e) {
+            return "Bye. Hope to see you again soon!\n(Warning: Error saving tasks)";
+        }
+        return "Bye. Hope to see you again soon!";
+    }
+
+    /**
+     * Handles the {@code list} command by returning all tasks in the task list.
+     *
+     * @return a formatted string of all tasks, or a message if the list is empty
+     */
+    private String handleList() {
+        List<Task> tasks = taskList.asList();
+        if (tasks.isEmpty()) return "Your task list is empty!";
+        StringBuilder sb = new StringBuilder("Here are the tasks in your list:\n");
+        for (int i = 0; i < tasks.size(); i++) {
+            sb.append(i + 1).append(".").append(tasks.get(i)).append("\n");
+        }
+        return sb.toString().trim();
+    }
+
+    /**
+     * Handles the {@code delete} command by removing a task at the specified index.
+     *
+     * @param args the argument string containing the index
+     * @return a confirmation message if deletion is successful,
+     *         or an error message if the index is invalid
+     */
+    private String handleDelete(String args) {
+        Integer idx = safeParseIndex(args);
+        if (idx == null) return ERR_DELETE_IDX;
+        try {
+            Task removed = taskList.delete(idx);
+            return "Noted. I've removed this task:\n  " + removed +
+                    "\nNow you have " + pluralizeTasks(taskList.asList().size()) + " in the list.";
+        } catch (Exception e) {
+            return ERR_DELETE_IDX;
+        }
+    }
+
+    /**
+     * Handles the {@code mark} command by marking a task as done.
+     *
+     * @param args the argument string containing the index
+     * @return a success message if marking succeeds, or an error message otherwise
+     */
+    private String handleMark(String args) {
+        Integer idx = safeParseIndex(args);
+        if (idx == null) return ERR_MARK_IDX;
+        try {
+            Task t = taskList.get(idx);
+            t.markDone();
+            return "Nice! I've marked this task as done:\n  " + t;
+        } catch (Exception e) {
+            return ERR_MARK_IDX;
+        }
+    }
+
+    /**
+     * Handles the {@code unmark} command by marking a task as not done.
+     *
+     * @param args the argument string containing the index
+     * @return a success message if unmarking succeeds, or an error message otherwise
+     */
+    private String handleUnmark(String args) {
+        Integer idx = safeParseIndex(args);
+        if (idx == null) return ERR_UNMARK_IDX;
+        try {
+            Task t = taskList.get(idx);
+            t.markUndone();
+            return "OK, I've marked this task as not done yet:\n  " + t;
+        } catch (Exception e) {
+            return ERR_UNMARK_IDX;
+        }
+    }
+
+    /**
+     * Handles the {@code todo} command by creating a new {@link Todo} task.
+     *
+     * @param args the argument string containing the task description
+     * @return a confirmation message, or an error message if description is empty
+     */
+    private String handleTodo(String args) {
+        if (args.isEmpty()) return ERR_TODO_EMPTY;
+        return addAndAcknowledge(new Todo(args));
+    }
+
+    /**
+     * Handles the {@code deadline} command by creating a new {@link Deadline} task.
+     *
+     * @param args the argument string containing the description and deadline
+     * @return a confirmation message, or an error message if input is invalid
+     */
+    private String handleDeadline(String args) {
+        try {
+            String[] parts = Parser.parseDeadline(args); // [desc, byStr]
+            String desc = parts[0];
+            String byStr = parts[1];
+            Task t = new Deadline(desc, DateTimeUtil.parseFlexible(byStr));
+            return addAndAcknowledge(t);
+        } catch (IllegalArgumentException e) {
+            return e.getMessage() != null ? e.getMessage() : USAGE_DEADLINE;
+        } catch (Exception e) {
+            return "Invalid date/time. Try formats like 2019-12-02 1800 or 2/12/2019 1800.";
+        }
+    }
+
+    /**
+     * Handles the {@code event} command by creating a new {@link Event} task.
+     *
+     * @param args the argument string containing the description, start, and end
+     * @return a confirmation message, or an error message if input is invalid
+     */
+    private String handleEvent(String args) {
+        try {
+            String[] parts = Parser.parseEvent(args); // [desc, fromStr, toStr]
+            String desc    = parts[0];
+            String fromStr = parts[1];
+            String toStr   = parts[2];
+            Task t = new Event(desc, DateTimeUtil.parseFlexible(fromStr), DateTimeUtil.parseFlexible(toStr));
+            return addAndAcknowledge(t);
+        } catch (IllegalArgumentException e) {
+            return e.getMessage() != null ? e.getMessage() : USAGE_EVENT;
+        } catch (Exception e) {
+            return "Invalid date/time for event. Use 2019-12-02 1800 or 2/12/2019 1800.";
+        }
+    }
+
+    /**
+     * Handles the {@code find} command by searching for tasks containing a keyword.
+     *
+     * @param args the argument string containing the search keyword
+     * @return a list of matching tasks, or an error/no-match message
+     */
+    private String handleFind(String args) {
+        String q = args.trim();
+        if (q.isEmpty()) return ERR_FIND_USAGE;
+        String query = q.toLowerCase();
+        StringBuilder sb = new StringBuilder("Here are the matching tasks in your list:\n");
+        int count = 0;
+        for (Task t : taskList.asList()) {
+            String d = t.getDescription();
+            if (d != null && d.toLowerCase().contains(query)) {
+                sb.append(++count).append(".").append(t).append("\n");
+            }
+        }
+        if (count == 0) return "No matching tasks found.";
+        return sb.toString().trim();
+    }
+
+    /**
+     * Adds a task to the task list and returns an acknowledgment message.
+     *
+     * @param t the task to add
+     * @return a confirmation message including the new task and task count
+     */
+    private String addAndAcknowledge(Task t) {
+        taskList.add(t);
+        return "Got it. I've added this task:\n  " + t +
+                "\nNow you have " + pluralizeTasks(taskList.asList().size()) + " in the list.";
+    }
+
+    /**
+     * Formats the number of tasks into a pluralized string.
+     *
+     * @param n the number of tasks
+     * @return a string like "1 task" or "3 tasks"
+     */
+    private static String pluralizeTasks(int n) {
+        return n + (n == 1 ? " task" : " tasks");
+    }
+
+    /**
+     * Safely parses a string into an integer index.
+     * <p>
+     * This method trims the string and attempts to convert it into an
+     * {@code Integer}. If the string is {@code null}, blank, or not a valid
+     * number, the method returns {@code null} instead of throwing an exception.
+     * <p>
+     * Useful for parsing user-supplied task indices where invalid or missing
+     * input should be handled gracefully.
+     *
+     * @param s the string to parse
+     * @return the parsed integer index, or {@code null} if parsing fails
+     */
+    private static Integer safeParseIndex(String s) {
+        if (s == null || s.isBlank()) return null;
+        try { return Integer.parseInt(s.trim()); }
+        catch (NumberFormatException e) { return null; }
+    }
+
+    /**
      * Processes user input and returns the appropriate response.
      * Uses the existing UI methods by capturing their System.out.print output.
      *
@@ -79,162 +295,23 @@ public class Rex {
     public String getResponse(String input) {
         assert input != null : "Input should never be null";
 
-        String trimmedInput = input.trim();
-        String lower = trimmedInput.toLowerCase();
+        final String trimmed = input.trim();
+        if (trimmed.isEmpty()) return UNKNOWN_COMMAND_MSG;
 
-        if (lower.equals("bye")) {
-            isRunning = false;
-            try {
-                Storage.save(DATA_PATH, new ArrayList<>(taskList.asList()));
-            } catch (Exception e) {
-                return "Bye. Hope to see you again soon!\n(Warning: Error saving tasks)";
-            }
-            return "Bye. Hope to see you again soon!";
+        final String cmd  = Parser.getCommand(trimmed);
+        final String args = Parser.getArguments(trimmed);
 
-        } else if (lower.equals("list")) {
-            if (taskList.asList().isEmpty()) {
-                return "Your task list is empty!";
-            }
-            StringBuilder sb = new StringBuilder();
-            sb.append("Here are the tasks in your list:\n");
-            List<Task> tasks = taskList.asList();
-            for (int i = 0; i < tasks.size(); i++) {
-                sb.append((i + 1)).append(".").append(tasks.get(i)).append("\n");
-            }
-            return sb.toString().trim();
-
-        } else if (lower.startsWith("delete")) {
-            // FIX: Check length before substring
-            if (trimmedInput.length() <= 7) {
-                return "Invalid task number for delete.";
-            }
-            try {
-                int idx = Integer.parseInt(trimmedInput.substring(7).trim());
-                Task removed = taskList.delete(idx);
-                return "Noted. I've removed this task:\n  " + removed +
-                        "\nNow you have " + taskList.asList().size() +
-                        (taskList.asList().size() == 1 ? " task" : " tasks") + " in the list.";
-            } catch (Exception e) {
-                return "Invalid task number for delete.";
-            }
-
-        } else if (lower.startsWith("mark ")) {
-            // FIX: Check length before substring
-            if (trimmedInput.length() <= 5) {
-                return "Invalid task number for mark.";
-            }
-            try {
-                int idx = Integer.parseInt(trimmedInput.substring(5).trim());
-                Task t = taskList.get(idx);
-                t.markDone();
-                return "Nice! I've marked this task as done:\n  " + t;
-            } catch (Exception e) {
-                return "Invalid task number for mark.";
-            }
-
-        } else if (lower.startsWith("unmark ")) {
-            // FIX: Check length before substring
-            if (trimmedInput.length() <= 7) {
-                return "Invalid task number for unmark.";
-            }
-            try {
-                int idx = Integer.parseInt(trimmedInput.substring(7).trim());
-                Task t = taskList.get(idx);
-                t.markUndone();
-                return "OK, I've marked this task as not done yet:\n  " + t;
-            } catch (Exception e) {
-                return "Invalid task number for unmark.";
-            }
-
-        } else if (lower.startsWith("todo ")) {
-            // FIX: Check length before substring
-            if (trimmedInput.length() <= 5) {
-                return "Todo description cannot be empty!";
-            }
-            String desc = trimmedInput.substring(5).trim();
-            if (desc.isEmpty()) {
-                return "Todo description cannot be empty!";
-            }
-            Task t = new Todo(desc);
-            taskList.add(t);
-            return "Got it. I've added this task:\n  " + t +
-                    "\nNow you have " + taskList.asList().size() +
-                    (taskList.asList().size() == 1 ? " task" : " tasks") + " in the list.";
-
-        } else if (lower.startsWith("deadline ")) {
-            // FIX: Check length before substring
-            if (trimmedInput.length() <= 9) {
-                return "Usage: deadline <description> /by <yyyy-MM-dd[ HHmm]>";
-            }
-            String body = trimmedInput.substring(9).trim();
-            int sep = body.indexOf(" /by ");
-            if (sep < 0) {
-                return "Usage: deadline <description> /by <yyyy-MM-dd[ HHmm]>";
-            }
-            String desc = body.substring(0, sep).trim();
-            String byStr = body.substring(sep + 5).trim();
-            if (desc.isEmpty()) {
-                return "Deadline description cannot be empty!";
-            }
-            try {
-                Task t = new Deadline(desc, DateTimeUtil.parseFlexible(byStr));
-                taskList.add(t);
-                return "Got it. I've added this task:\n  " + t +
-                        "\nNow you have " + taskList.asList().size() +
-                        (taskList.asList().size() == 1 ? " task" : " tasks") + " in the list.";
-            } catch (Exception e) {
-                return "Invalid date/time. Try formats like 2019-12-02 1800 or 2/12/2019 1800.";
-            }
-
-        } else if (lower.startsWith("event ")) {
-            // FIX: Check length before substring
-            if (trimmedInput.length() <= 6) {
-                return "Usage: event <desc> /from <yyyy-MM-dd[ HHmm]> /to <yyyy-MM-dd[ HHmm]>";
-            }
-            String body = trimmedInput.substring(6).trim();
-            int fromIdx = body.indexOf(" /from ");
-            int toIdx = body.indexOf(" /to ");
-            if (fromIdx < 0 || toIdx < 0 || toIdx <= fromIdx) {
-                return "Usage: event <desc> /from <yyyy-MM-dd[ HHmm]> /to <yyyy-MM-dd[ HHmm]>";
-            }
-            String desc = body.substring(0, fromIdx).trim();
-            String fromStr = body.substring(fromIdx + 7, toIdx).trim();
-            String toStr = body.substring(toIdx + 5).trim();
-            if (desc.isEmpty()) {
-                return "Event description cannot be empty!";
-            }
-            try {
-                Task t = new Event(desc, DateTimeUtil.parseFlexible(fromStr), DateTimeUtil.parseFlexible(toStr));
-                taskList.add(t);
-                return "Got it. I've added this task:\n  " + t +
-                        "\nNow you have " + taskList.asList().size() +
-                        (taskList.asList().size() == 1 ? " task" : " tasks") + " in the list.";
-            } catch (Exception e) {
-                return "Invalid date/time for event. Use 2019-12-02 1800 or 2/12/2019 1800.";
-            }
-
-        } else if (lower.startsWith("find")) {
-            String body = trimmedInput.length() >= 5 ? trimmedInput.substring(5).trim() : "";
-            if (body.isEmpty()) {
-                return "Usage: find <keyword>";
-            }
-            String query = body.toLowerCase();
-            StringBuilder sb = new StringBuilder();
-            sb.append("Here are the matching tasks in your list:\n");
-            int count = 0;
-            for (Task t : taskList.asList()) {
-                String desc = t.getDescription();
-                if (desc != null && desc.toLowerCase().contains(query)) {
-                    sb.append(++count).append(".").append(t).append("\n");
-                }
-            }
-            if (count == 0) {
-                return "No matching tasks found.";
-            }
-            return sb.toString().trim();
-
-        } else {
-            return "Unknown command. Try 'list', 'todo', 'deadline', 'event', 'mark', 'unmark', 'delete', 'find', or 'bye'.";
+        switch (cmd) {
+            case "bye":      return handleBye();
+            case "list":     return handleList();
+            case "delete":   return handleDelete(args);
+            case "mark":     return handleMark(args);
+            case "unmark":   return handleUnmark(args);
+            case "todo":     return handleTodo(args);
+            case "deadline": return handleDeadline(args);
+            case "event":    return handleEvent(args);
+            case "find":     return handleFind(args);
+            default:         return UNKNOWN_COMMAND_MSG;
         }
     }
 

--- a/src/main/java/seedu/rex/utils/Parser.java
+++ b/src/main/java/seedu/rex/utils/Parser.java
@@ -1,0 +1,104 @@
+package seedu.rex.utils;
+
+import seedu.rex.ui.Rex;
+
+/**
+ * The {@code Parser} class handles parsing of user input for the Rex chatbot.
+ * <p>
+ * It provides helper methods to extract command words and arguments
+ * from raw user input, as well as specific parsers for complex commands
+ * such as {@code deadline} and {@code event}.
+ * <p>
+ * This class centralizes input parsing logic to keep {@link Rex}
+ * focused on command execution.
+ */
+public class Parser {
+
+    /**
+     * Extracts the command word from the user input.
+     * <p>
+     * The command word is the first token (before the first space).
+     * It is converted to lowercase for case-insensitive matching.
+     *
+     * @param input the full user input string
+     * @return the command word in lowercase, or an empty string if input is empty
+     */
+    public static String getCommand(String input) {
+        if (input == null || input.isBlank()) {
+            return "";
+        }
+        return input.split(" ")[0].toLowerCase();
+    }
+
+    /**
+     * Extracts the arguments from the user input.
+     * <p>
+     * The arguments are everything after the first space. If no space is
+     * present, this method returns an empty string.
+     *
+     * @param input the full user input string
+     * @return the argument string, or an empty string if none exist
+     */
+    public static String getArguments(String input) {
+        if (input == null) {
+            return "";
+        }
+        int firstSpace = input.indexOf(" ");
+        return firstSpace == -1 ? "" : input.substring(firstSpace + 1).trim();
+    }
+
+    /**
+     * Parses the arguments for a {@code deadline} command.
+     * <p>
+     * Expected format:
+     * <pre>
+     *   description /by yyyy-MM-dd[ HHmm]
+     * </pre>
+     *
+     * @param args the argument string after the "deadline" keyword
+     * @return a two-element array: [description, deadline string]
+     * @throws IllegalArgumentException if description or deadline is missing
+     */
+    public static String[] parseDeadline(String args) {
+        int sep = args.indexOf("/by");
+        if (sep == -1) {
+            throw new IllegalArgumentException("Usage: deadline <desc> /by <yyyy-MM-dd[ HHmm]>");
+        }
+        String desc = args.substring(0, sep).trim();
+        String by = args.substring(sep + 3).trim();
+        if (desc.isEmpty() || by.isEmpty()) {
+            throw new IllegalArgumentException("Deadline requires description and date/time.");
+        }
+        return new String[]{desc, by};
+    }
+
+    /**
+     * Parses the arguments for an {@code event} command.
+     * <p>
+     * Expected format:
+     * <pre>
+     *   description /from yyyy-MM-dd[ HHmm] /to yyyy-MM-dd[ HHmm]
+     * </pre>
+     *
+     * @param args the argument string after the "event" keyword
+     * @return a three-element array: [description, from, to]
+     * @throws IllegalArgumentException if description, from, or to is missing
+     */
+    public static String[] parseEvent(String args) {
+        int fromIdx = args.indexOf("/from");
+        int toIdx = args.indexOf("/to");
+        if (fromIdx == -1 || toIdx == -1 || toIdx <= fromIdx) {
+            throw new IllegalArgumentException("Usage: event <desc> /from <start> /to <end>");
+        }
+
+        String desc = args.substring(0, fromIdx).trim();
+        String from = args.substring(fromIdx + 5, toIdx).trim();
+        String to = args.substring(toIdx + 3).trim();
+
+        if (desc.isEmpty() || from.isEmpty() || to.isEmpty()) {
+            throw new IllegalArgumentException("Event requires description, start, and end date/time.");
+        }
+
+        return new String[]{desc, from, to};
+    }
+}


### PR DESCRIPTION
**Summary**
This PR enhances the find command to allow partial substring matching when searching for tasks.

**Changes**
- Updated Rex.getResponse() handling for find
- Task descriptions are now checked using contains instead of requiring exact matches.
- Matching is case-insensitive.
- Added iteration through all tasks to build a result list dynamically.
- Returns "No matching tasks found." when no results exist.
- Preserves existing behaviour for full matches (backward-compatible).